### PR TITLE
fix: adjustment of params in New-AzADServicePrincipal

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -93,15 +93,7 @@ Execute all these steps below to setup your evironment before running the Hands-
         $env:AZURE_DEVOPS_EXT_PAT="<my PAT goes here>"
         ```
 
-2. Connect and authenticate to your Azure account.
-
-    - **On the Azure PowerShell terminal**: connect to Azure with your authenticated account.
-
-        ```powershell
-        Connect-AzAccount -UseDeviceAuthentication
-        ```
-
-3. Run the deployment script
+2. Run the deployment script
 
     -  **On the Azure PowerShell terminal**: run the `Deploy-AzurePreReqs.ps1` script to deploy the pre-required Azure resources:
 

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -52,7 +52,7 @@ function CreateOrGetServicePrincipal
         $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($servicePrincipal.Secret)
         $UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
 
-        LogInfo -Message "Service principal secret '$UnsecureSecret'
+        LogInfo -Message "Service principal secret '$UnsecureSecret'"
 
 	}
 	else

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -17,7 +17,7 @@ function SetupServicePrincipals
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
-        $servicePrincipals += @{        
+        $servicePrincipals += [PSCustomObject]@{        
             objectId = $servicePrincipal.Id;
             clientId = $servicePrincipal.ApplicationId;
             displayName = $servicePrincipal.DisplayName;

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -17,7 +17,7 @@ function SetupServicePrincipals
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
-        $secPass = ConvertTo-SecureString [-String] $servicePrincipal.PasswordCredentials.SecretText
+        $secPass = ConvertTo-SecureString $servicePrincipal.PasswordCredentials.SecretText  -AsPlainText -Force
 
         $servicePrincipals += @{        
             $servicePrincipal.DisplayName = @{

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -17,6 +17,11 @@ function SetupServicePrincipals
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
+        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($servicePrincipal.Secret)
+        $UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+
+        LogInfo -Message "Service Principal secret '$UnsecureSecret'"
+        
         $servicePrincipals += @{        
             $servicePrincipal.DisplayName = @{
                 "objectId" = $servicePrincipal.Id

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -22,7 +22,7 @@ function SetupServicePrincipals
                 "objectId" = $servicePrincipal.Id
                 "clientId" = $servicePrincipal.ApplicationId
 				"displayName" = $servicePrincipal.DisplayName
-                "clientSecret" = $servicePrincipal.Secret
+                "clientSecret" = $servicePrincipal.clientSecret
             }
         }
     }

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -71,7 +71,7 @@ function SetupEnvironments {
 		BeginScope -Scope "Environment: $envKey"
 		
 		$enviroment = $Configuration.environments[$envKey]
-		$servicePrincipal = $ServicePrincipals[$enviroment.servicePrincipalName]
+		$servicePrincipal = $ServicePrincipals[0]
 
         Write-Output "servicePrincipal Loaded"
         Write-Output $servicePrincipal | Get-Member

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -17,14 +17,12 @@ function SetupServicePrincipals
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
-        LogInfo -Message "'$servicePrincipal'"
-
         $secPass = ConvertTo-SecureString $servicePrincipal.PasswordCredentials.SecretText  -AsPlainText -Force
 
         $servicePrincipals += @{        
             $servicePrincipal.DisplayName = @{
                 "objectId" = $servicePrincipal.Id
-                "clientId" = $servicePrincipal.ApplicationId
+                "clientId" = $servicePrincipal.AppId
                 "displayName" = $servicePrincipal.DisplayName
                 "clientSecret" = $secPass
             }

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -17,6 +17,8 @@ function SetupServicePrincipals
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
+        LogInfo -Message "'$servicePrincipal'"
+
         $secPass = ConvertTo-SecureString $servicePrincipal.PasswordCredentials.SecretText  -AsPlainText -Force
 
         $servicePrincipals += @{        

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -19,7 +19,7 @@ function SetupServicePrincipals
 
         LogInfo -Message "Service principal password '$servicePrincipal'"
 
-        $servicePrincipals += [PSCustomObject]@{        
+        $servicePrincipals += @{        
             objectId = $servicePrincipal.Id;
             clientId = $servicePrincipal.ApplicationId;
             displayName = $servicePrincipal.DisplayName;

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -17,12 +17,14 @@ function SetupServicePrincipals
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
+        $secPass = ConvertTo-SecureString [-String] $servicePrincipal.PasswordCredentials.SecretText
+
         $servicePrincipals += @{        
             $servicePrincipal.DisplayName = @{
                 "objectId" = $servicePrincipal.Id
                 "clientId" = $servicePrincipal.ApplicationId
                 "displayName" = $servicePrincipal.DisplayName
-                "clientSecret" = ConvertTo-SecureString [-String] $servicePrincipal.PasswordCredentials.SecretText
+                "clientSecret" = $secPass
             }
         }
 

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -72,6 +72,9 @@ function SetupEnvironments {
 		
 		$enviroment = $Configuration.environments[$envKey]
 		$servicePrincipal = $ServicePrincipals[$enviroment.servicePrincipalName]
+
+        Write-Output "servicePrincipal Loaded"
+        Write-Output $servicePrincipal | Get-Member
 		
 		Set-AzContext -Subscription $enviroment.subscriptionId
 

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -22,7 +22,7 @@ function SetupServicePrincipals
                 "objectId" = $servicePrincipal.Id
                 "clientId" = $servicePrincipal.ApplicationId
 				"displayName" = $servicePrincipal.DisplayName
-                "clientSecret" = $servicePrincipal.clientSecret
+                "clientSecret" = $servicePrincipal.Secret
             }
         }
     }
@@ -48,6 +48,12 @@ function CreateOrGetServicePrincipal
         LogInfo -Message "Trying to create Service principal with DisplayName param with '$Name'"
 		$servicePrincipal = New-AzADServicePrincipal -DisplayName $Name
 		LogInfo -Message "Service principal '$Name' created."
+
+        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($servicePrincipal.Secret)
+        $UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+
+        LogInfo -Message "Service principal secret '$UnsecureSecret'
+
 	}
 	else
 	{

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -43,7 +43,7 @@ function CreateOrGetServicePrincipal
 
 	if (! $servicePrincipal)
 	{ 
-		$servicePrincipal = New-AzADServicePrincipal -DisplayName $Name -SkipAssignment
+		$servicePrincipal = New-AzADServicePrincipal -DisplayName $Name
 		LogInfo -Message "Service principal '$Name' created."
 	}
 	else

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -68,11 +68,9 @@ function SetupEnvironments {
 		
 		$enviroment = $Configuration.environments[$envKey]
 		
-        Write-Output $ServicePrincipals.Length
-        
         $servicePrincipal = $ServicePrincipals[0]
 
-        Write-Output "servicePrincipal Loaded"
+        Write-Output $ServicePrincipals[0]
         Write-Output $servicePrincipal
 		
 		Set-AzContext -Subscription $enviroment.subscriptionId

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -17,14 +17,15 @@ function SetupServicePrincipals
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
-        LogInfo -Message "Service principal password '$servicePrincipal'"
-
         $servicePrincipals += @{        
             objectId = $servicePrincipal.Id;
             clientId = $servicePrincipal.ApplicationId;
             displayName = $servicePrincipal.DisplayName;
             clientSecret = $servicePrincipal.PasswordCredentials.SecretText;
         }
+
+        $sv0 = $servicePrincipals[0]
+        LogInfo -Message "Service principals[0]: '$sv0'"
     }
 
 	EndScope

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -17,15 +17,11 @@ function SetupServicePrincipals
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
-        LogInfo -Message "Service Principal secret '$UnsecureSecret'"
-        
         $servicePrincipals += @{        
-            $servicePrincipal.DisplayName = @{
-                "objectId" = $servicePrincipal.Id
-                "clientId" = $servicePrincipal.ApplicationId
-				"displayName" = $servicePrincipal.DisplayName
-                "clientSecret" = $servicePrincipal.PasswordCredentials.PlanText
-            }
+            objectId = $servicePrincipal.Id;
+            clientId = $servicePrincipal.ApplicationId;
+            displayName = $servicePrincipal.DisplayName;
+            clientSecret = $servicePrincipal.PasswordCredentials.SecretText;
         }
     }
 

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -49,10 +49,10 @@ function CreateOrGetServicePrincipal
 		$servicePrincipal = New-AzADServicePrincipal -DisplayName $Name
 		LogInfo -Message "Service principal '$Name' created."
 
-        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($servicePrincipal.Secret)
-        $UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+        # $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($servicePrincipal.Secret)
+        # $UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
 
-        LogInfo -Message "Service principal secret '$UnsecureSecret'"
+        # LogInfo -Message "Service principal secret '$UnsecureSecret'"
 
 	}
 	else

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -39,10 +39,13 @@ function CreateOrGetServicePrincipal
         [Parameter(Mandatory)] [string] $Name
     )
 
+    LogInfo -Message "Trying to get Service principal '$Name'."
+
 	$servicePrincipal = Get-AzADServicePrincipal -DisplayName $Name
 
 	if (! $servicePrincipal)
 	{ 
+        LogInfo -Message "Trying to create Service principal with DisplayName param with '$Name'"
 		$servicePrincipal = New-AzADServicePrincipal -DisplayName $Name
 		LogInfo -Message "Service principal '$Name' created."
 	}

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -11,13 +11,13 @@ function SetupServicePrincipals
 
 	BeginScope -Scope "Service Principals"
 
-    $servicePrincipals = @()
+    $servicePrincipals = @{}
 
     foreach ($principalName in $Configuration.servicePrincipals)
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
-        LogInfo -Message "Service principal password '$servicePrincipal.PasswordCredentials.SecretText'"
+        LogInfo -Message "Service principal password '$servicePrincipal'"
 
         $servicePrincipals += [PSCustomObject]@{        
             objectId = $servicePrincipal.Id;

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -22,7 +22,7 @@ function SetupServicePrincipals
                 "objectId" = $servicePrincipal.Id
                 "clientId" = $servicePrincipal.ApplicationId
                 "displayName" = $servicePrincipal.DisplayName
-                "clientSecret" = $servicePrincipal.PasswordCredentials.SecretText
+                "clientSecret" = ConvertTo-SecureString [-String] $servicePrincipal.PasswordCredentials.SecretText
             }
         }
 

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -11,7 +11,7 @@ function SetupServicePrincipals
 
 	BeginScope -Scope "Service Principals"
 
-    $servicePrincipals = @{}
+    $servicePrincipals = @()
 
     foreach ($principalName in $Configuration.servicePrincipals)
 	{

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -71,10 +71,13 @@ function SetupEnvironments {
 		BeginScope -Scope "Environment: $envKey"
 		
 		$enviroment = $Configuration.environments[$envKey]
-		$servicePrincipal = $ServicePrincipals[0]
+		
+        Write-Output $ServicePrincipals.Length
+        
+        $servicePrincipal = $ServicePrincipals[0]
 
         Write-Output "servicePrincipal Loaded"
-        Write-Output $servicePrincipal | Get-Member
+        Write-Output $servicePrincipal
 		
 		Set-AzContext -Subscription $enviroment.subscriptionId
 

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -48,12 +48,6 @@ function CreateOrGetServicePrincipal
         LogInfo -Message "Trying to create Service principal with DisplayName param with '$Name'"
 		$servicePrincipal = New-AzADServicePrincipal -DisplayName $Name
 		LogInfo -Message "Service principal '$Name' created."
-
-        # $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($servicePrincipal.Secret)
-        # $UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
-
-        # LogInfo -Message "Service principal secret '$UnsecureSecret'"
-
 	}
 	else
 	{

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -17,6 +17,8 @@ function SetupServicePrincipals
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
+        LogInfo -Message "Service principal password '$servicePrincipal.PasswordCredentials.SecretText'"
+
         $servicePrincipals += [PSCustomObject]@{        
             objectId = $servicePrincipal.Id;
             clientId = $servicePrincipal.ApplicationId;

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -48,7 +48,6 @@ function CreateOrGetServicePrincipal
 
 	if (! $servicePrincipal)
 	{ 
-        LogInfo -Message "Trying to create Service principal with DisplayName param with '$Name'"
 		$servicePrincipal = New-AzADServicePrincipal -DisplayName $Name
 		LogInfo -Message "Service principal '$Name' created."
 	}
@@ -73,7 +72,7 @@ function SetupEnvironments {
 		
 		$enviroment = $Configuration.environments[$envKey]
 		
-        #Devido ao fato de termos somente 1 item no array
+        #Only one item in array
         $servicePrincipal = $ServicePrincipals[$Configuration.servicePrincipals[0]]
 
         Set-AzContext -Subscription $enviroment.subscriptionId

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -18,14 +18,14 @@ function SetupServicePrincipals
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
         $servicePrincipals += @{        
-            objectId = $servicePrincipal.Id;
-            clientId = $servicePrincipal.ApplicationId;
-            displayName = $servicePrincipal.DisplayName;
-            clientSecret = $servicePrincipal.PasswordCredentials.SecretText;
+            $servicePrincipal.DisplayName = @{
+                "objectId" = $servicePrincipal.Id
+                "clientId" = $servicePrincipal.ApplicationId
+                "displayName" = $servicePrincipal.DisplayName
+                "clientSecret" = $servicePrincipal.PasswordCredentials.SecretText
+            }
         }
 
-        $sv0 = $servicePrincipals[0]
-        LogInfo -Message "Service principals[0]: '$sv0'"
     }
 
 	EndScope
@@ -71,12 +71,10 @@ function SetupEnvironments {
 		
 		$enviroment = $Configuration.environments[$envKey]
 		
-        $servicePrincipal = $ServicePrincipals[0]
+        #Devido ao fato de termos somente 1 item no array
+        $servicePrincipal = $ServicePrincipals[$Configuration.servicePrincipals[0]]
 
-        Write-Output $ServicePrincipals[0]
-        Write-Output $servicePrincipal
-		
-		Set-AzContext -Subscription $enviroment.subscriptionId
+        Set-AzContext -Subscription $enviroment.subscriptionId
 
         AssignRoleIfNotExists -RoleName "Owner" -ObjectId $servicePrincipal.objectId -SubscriptionId $enviroment.subscriptionId
 

--- a/quickstart/scripts/modules/Azure.psm1
+++ b/quickstart/scripts/modules/Azure.psm1
@@ -17,9 +17,6 @@ function SetupServicePrincipals
 	{
 		$servicePrincipal = CreateOrGetServicePrincipal -Name $principalName
 
-        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($servicePrincipal.Secret)
-        $UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
-
         LogInfo -Message "Service Principal secret '$UnsecureSecret'"
         
         $servicePrincipals += @{        
@@ -27,7 +24,7 @@ function SetupServicePrincipals
                 "objectId" = $servicePrincipal.Id
                 "clientId" = $servicePrincipal.ApplicationId
 				"displayName" = $servicePrincipal.DisplayName
-                "clientSecret" = $servicePrincipal.Secret
+                "clientSecret" = $servicePrincipal.PasswordCredentials.PlanText
             }
         }
     }

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -259,7 +259,7 @@ function SetupServiceConnection {
         $Pass = $ServicePrincipal.PasswordCredentials.SecretText
         LogInfo -Message "Loggin Secret: '$Pass'"
 
-        if (! $ServicePrincipal.PasswordCredentials.SecretText) {
+        if (! $Pass) {
             throw "Client Secret was not present in the request."
         }
 

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -256,13 +256,14 @@ function SetupServiceConnection {
     if (!$serviceEndpointId) {
         LogInfo -Message "No '$serviceConnectionName' service connection found. Creating..."
 
-        LogInfo -Message "Loggin Secret: '$ServicePrincipal.PasswordCredentials.SecretText'"
+        $Pass = $ServicePrincipal.PasswordCredentials.SecretText
+        LogInfo -Message "Loggin Secret: '$Pass'"
 
         if (! $ServicePrincipal.PasswordCredentials.SecretText) {
             throw "Client Secret was not present in the request."
         }
 
-        $env:AZURE_DEVOPS_EXT_AZURE_RM_SERVICE_PRINCIPAL_KEY = ConvertFrom-SecureString -SecureString $ServicePrincipal.PasswordCredentials.SecretText -AsPlainText
+        $env:AZURE_DEVOPS_EXT_AZURE_RM_SERVICE_PRINCIPAL_KEY = ConvertFrom-SecureString -SecureString $Pass -AsPlainText
 
         $subscription = Get-AzSubscription | Where-Object { $_.Id -eq $Environment.subscriptionId }
 

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -266,7 +266,7 @@ function SetupServiceConnection {
 
         $subscription = Get-AzSubscription | Where-Object { $_.Id -eq $Environment.subscriptionId }
 
-        $serviceEndpointId = az devops service-endpoint azurerm create `
+        az devops service-endpoint azurerm create `
             --azure-rm-service-principal-id $ServicePrincipal.clientId `
             --azure-rm-subscription-id $subscription.Id `
             --azure-rm-subscription-name $subscription.Name `
@@ -277,8 +277,12 @@ function SetupServiceConnection {
             --query 'id' -o tsv
 
 		LogInfo -Message "Service connection '$serviceConnectionName' created."
+
+        #Retrieving ID of service-endepoint created
+        $serviceEndpointId = az devops service-endpoint list --org $organizationURI -p $project --query "[?name=='$serviceConnectionName'].id" -o tsv
+
         LogInfo -Message "Service connection ID bellow:"
-        Write-Output $serviceEndpointId | Get-Member
+        Write-Output $serviceEndpointId
     }
 
 	LogInfo -Message "Granting acess permission to all pipelines on the '$serviceConnectionName' service connection..."

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -256,14 +256,13 @@ function SetupServiceConnection {
     if (!$serviceEndpointId) {
         LogInfo -Message "No '$serviceConnectionName' service connection found. Creating..."
 
-        LogInfo -Message "loggin clientSecret: '$ServicePrincipal.clientSecret'"
-        LogInfo -Message "loggin Secret: '$ServicePrincipal.Secret'"
+        LogInfo -Message "Loggin Secret: '$ServicePrincipal.PasswordCredentials.SecretText'"
 
-        if (! $ServicePrincipal.clientSecret) {
+        if (! $ServicePrincipal.PasswordCredentials.SecretText) {
             throw "Client Secret was not present in the request."
         }
 
-        $env:AZURE_DEVOPS_EXT_AZURE_RM_SERVICE_PRINCIPAL_KEY = ConvertFrom-SecureString -SecureString $ServicePrincipal.clientSecret -AsPlainText
+        $env:AZURE_DEVOPS_EXT_AZURE_RM_SERVICE_PRINCIPAL_KEY = ConvertFrom-SecureString -SecureString $ServicePrincipal.PasswordCredentials.SecretText -AsPlainText
 
         $subscription = Get-AzSubscription | Where-Object { $_.Id -eq $Environment.subscriptionId }
 

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -256,8 +256,7 @@ function SetupServiceConnection {
     if (!$serviceEndpointId) {
         LogInfo -Message "No '$serviceConnectionName' service connection found. Creating..."
 
-        $Pass = ConvertTo-SecureString [-String] $ServicePrincipal.clientSecret
-        LogInfo -Message "Loggin Secret: '$Pass'"
+        $Pass = $ServicePrincipal.clientSecret
 
         if (! $Pass) {
             throw "Client Secret was not present in the request."

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -256,7 +256,7 @@ function SetupServiceConnection {
     if (!$serviceEndpointId) {
         LogInfo -Message "No '$serviceConnectionName' service connection found. Creating..."
 
-        $Pass = $ServicePrincipal.clientSecret
+        $Pass = ConvertTo-SecureString [-String] $ServicePrincipal.clientSecret
         LogInfo -Message "Loggin Secret: '$Pass'"
 
         if (! $Pass) {

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -277,7 +277,7 @@ function SetupServiceConnection {
             --query 'id' -o tsv
 
 		LogInfo -Message "Service connection '$serviceConnectionName' created."
-
+        LogInfo -Message "Service connection ID bellow:"
         Write-Output $serviceEndpointId
     }
 

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -278,8 +278,6 @@ function SetupServiceConnection {
 
 		LogInfo -Message "Service connection '$serviceConnectionName' created."
         
-        LogInfo -Message "Service connection ID bellow:"
-        Write-Output $serviceEndpointId
     }
 
 	LogInfo -Message "Granting acess permission to all pipelines on the '$serviceConnectionName' service connection..."

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -278,7 +278,7 @@ function SetupServiceConnection {
 
 		LogInfo -Message "Service connection '$serviceConnectionName' created."
         LogInfo -Message "Service connection ID bellow:"
-        Write-Output $serviceEndpointId
+        Write-Output $serviceEndpointId | Get-Member
     }
 
 	LogInfo -Message "Granting acess permission to all pipelines on the '$serviceConnectionName' service connection..."

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -256,6 +256,9 @@ function SetupServiceConnection {
     if (!$serviceEndpointId) {
         LogInfo -Message "No '$serviceConnectionName' service connection found. Creating..."
 
+        LogInfo -Message "loggin clientSecret: '$ServicePrincipal.clientSecret'"
+        LogInfo -Message "loggin Secret: '$ServicePrincipal.Secret'"
+
         if (! $ServicePrincipal.clientSecret) {
             throw "Client Secret was not present in the request."
         }

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -262,7 +262,7 @@ function SetupServiceConnection {
             throw "Client Secret was not present in the request."
         }
 
-        $env:AZURE_DEVOPS_EXT_AZURE_RM_SERVICE_PRINCIPAL_KEY = ConvertFrom-SecureString -SecureString $Pass -AsPlainText
+        $env:AZURE_DEVOPS_EXT_AZURE_RM_SERVICE_PRINCIPAL_KEY = $Pass
 
         $subscription = Get-AzSubscription | Where-Object { $_.Id -eq $Environment.subscriptionId }
 

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -266,7 +266,7 @@ function SetupServiceConnection {
 
         $subscription = Get-AzSubscription | Where-Object { $_.Id -eq $Environment.subscriptionId }
 
-        az devops service-endpoint azurerm create `
+        $serviceEndpointId = az devops service-endpoint azurerm create `
             --azure-rm-service-principal-id $ServicePrincipal.clientId `
             --azure-rm-subscription-id $subscription.Id `
             --azure-rm-subscription-name $subscription.Name `
@@ -274,13 +274,10 @@ function SetupServiceConnection {
             --name $serviceConnectionName `
             --organization $organizationURI `
             --project $project `
-            --query 'id' -o tsv
+            --query "'$serviceConnectionName'.id" -o tsv
 
 		LogInfo -Message "Service connection '$serviceConnectionName' created."
-
-        #Retrieving ID of service-endepoint created
-        $serviceEndpointId = az devops service-endpoint list --org $organizationURI -p $project --query "[?name=='$serviceConnectionName'].id" -o tsv
-
+        
         LogInfo -Message "Service connection ID bellow:"
         Write-Output $serviceEndpointId
     }

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -256,7 +256,7 @@ function SetupServiceConnection {
     if (!$serviceEndpointId) {
         LogInfo -Message "No '$serviceConnectionName' service connection found. Creating..."
 
-        $Pass = $ServicePrincipal.PasswordCredentials.SecretText
+        $Pass = $ServicePrincipal.clientSecret
         LogInfo -Message "Loggin Secret: '$Pass'"
 
         if (! $Pass) {

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -274,7 +274,7 @@ function SetupServiceConnection {
             --name $serviceConnectionName `
             --organization $organizationURI `
             --project $project `
-            --query "'$serviceConnectionName'.id" -o tsv
+            --query "id" -o tsv
 
 		LogInfo -Message "Service connection '$serviceConnectionName' created."
         

--- a/quickstart/scripts/modules/AzureDevOps.psm1
+++ b/quickstart/scripts/modules/AzureDevOps.psm1
@@ -277,6 +277,8 @@ function SetupServiceConnection {
             --query 'id' -o tsv
 
 		LogInfo -Message "Service connection '$serviceConnectionName' created."
+
+        Write-Output $serviceEndpointId
     }
 
 	LogInfo -Message "Granting acess permission to all pipelines on the '$serviceConnectionName' service connection..."


### PR DESCRIPTION
- Documentation adjustment
- Removed -SkipAssignment invalid parameter of the above method 
- Change the hashtable value of the Service's Principal Creadentials to create objects
- Added more console log infos

source: [microsoft-doc](https://docs.microsoft.com/en-us/powershell/module/az.resources/new-azadserviceprincipal?view=azps-7.1.0)